### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.16", "3.17.91", "3.18"],
+    "shell-version": ["3.16", "3.17.91", "3.18", "3.20"],
     "uuid": "appindicatorsupport@rgcjonas.gmail.com", 
     "name": "KStatusNotifierItem/AppIndicator Support",
     "description": "Adds KStatusNotifierItem support to the Shell",


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!
