### PR TITLE
Works on Gnome 3.22 too

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.16", "3.17.91", "3.18", "3.20"],
+    "shell-version": ["3.16", "3.17.91", "3.18", "3.20", "3.22"],
     "uuid": "appindicatorsupport@rgcjonas.gmail.com", 
     "name": "KStatusNotifierItem/AppIndicator Support",
     "description": "Adds KStatusNotifierItem support to the Shell",


### PR DESCRIPTION
Confirmed by https://github.com/rgcjonas/gnome-shell-extension-appindicator/pull/61#issuecomment-261399433.